### PR TITLE
Font-size improvement

### DIFF
--- a/Classes/Views/DetailsHeaderView.m
+++ b/Classes/Views/DetailsHeaderView.m
@@ -83,6 +83,10 @@
     entry = [entry_ retain];
     
     NSString *body = [entry body];
+    
+    // Make font of full comments a bit bigger & more readable
+    body = [NSString stringWithFormat:@"%@%@%@", @"<font size=\"4\" face=\"Georgia\">", body, @"</font>"];
+    
     NSData *data = [body dataUsingEncoding:NSUTF8StringEncoding];
     NSAttributedString *attributed = [[NSAttributedString alloc] initWithHTML:data baseURL:kHNWebsiteURL documentAttributes:NULL];
     [textView setAttributedString:[attributed autorelease]];


### PR DESCRIPTION
Thought the default text size for full size comments was a bit too small. Made a small adjustment to "fix" this. Maybe some UI to adjust this would be great. 

PS.
I am just starting to learn obj-c, so probably my method is terrible ;) Nice learning example btw. Thanks for open-sourcing (I bought it too :))
