### PR TITLE
URL encode search query string

### DIFF
--- a/Classes/HNKit/HNAPISearch.h
+++ b/Classes/HNKit/HNAPISearch.h
@@ -7,6 +7,7 @@
 
 #import <Foundation/Foundation.h>
 #import "HNKit.h"
+#import "NSString+URLEncoding.h"
 
 @interface HNAPISearch : NSObject <UIApplicationDelegate> {
 	NSMutableData *responseData;

--- a/Classes/HNKit/HNAPISearch.m
+++ b/Classes/HNKit/HNAPISearch.m
@@ -106,10 +106,11 @@
 
 - (void)performSearch:(NSString *)searchQuery {
 	NSString *paramsString = nil;
+	NSString *encodedQuery = [searchQuery stringByURLEncodingString];
 	if (searchType == kHNSearchTypeInteresting) {
-		paramsString = [NSString stringWithFormat:kHNSearchParamsInteresting, searchQuery];
+		paramsString = [NSString stringWithFormat:kHNSearchParamsInteresting, encodedQuery];
 	} else {
-		paramsString = [NSString stringWithFormat:kHNSearchParamsRecent, searchQuery];
+		paramsString = [NSString stringWithFormat:kHNSearchParamsRecent, encodedQuery];
 	}
 
 	NSString *urlString = [NSString stringWithFormat:kHNSearchBaseURL, paramsString];


### PR DESCRIPTION
I missed URL encoding!  The other changes you made look good.  I had made a note to use the loading indicator and then spaced it.
