### PR TITLE
Added article title above url to email body when sharing article

### DIFF
--- a/Classes/Controllers/SharingController.m
+++ b/Classes/Controllers/SharingController.m
@@ -62,7 +62,7 @@
         InstapaperActivity *instapaperActivity = [[InstapaperActivity alloc] init];
         OpenInSafariActivity *openInSafariActivity = [[OpenInSafariActivity alloc] init];
         
-        NSArray *activityItems = [NSArray arrayWithObject:url];
+        NSArray *activityItems = @[title, url];
         NSArray *applicationActivities = [NSArray arrayWithObjects:instapaperActivity, openInSafariActivity, nil];
 
         [instapaperActivity release];


### PR DESCRIPTION
While Apple fixes the bug that prevents editing the subject of emails composed through UIActivityViewController (http://stackoverflow.com/questions/12623260/how-do-i-set-recipients-for-uiactivityviewcontroller-in-ios-6?rq=1), this should at least improve the 'share via email' experience a bit.
