### PR TITLE
Updated BrowserController so can now render in landscape

### DIFF
--- a/Classes/Controllers/NavigationController.m
+++ b/Classes/Controllers/NavigationController.m
@@ -11,6 +11,7 @@
 #import "LoginController.h"
 #import "UIColor+Orange.h"
 #import "HackerNewsLoginController.h"
+#import "BrowserController.h"
 
 @implementation NavigationController
 @synthesize loginDelegate;
@@ -87,6 +88,18 @@
     [loginDelegate navigationControllerRequestedSessions:self];
 }
 
-AUTOROTATION_FOR_PAD_ONLY
+- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation {
+    if ([self.visibleViewController class] == [BrowserController class]) {
+        return YES;
+    }
+    return ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) || (toInterfaceOrientation == UIInterfaceOrientationPortrait);
+}
+
+- (NSUInteger)supportedInterfaceOrientations {
+    if ([self.visibleViewController class] == [BrowserController class]) {
+        return UIInterfaceOrientationMaskAll;
+    }
+    return ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad ? UIInterfaceOrientationMaskAll : UIInterfaceOrientationMaskPortrait);
+}
 
 @end

--- a/Info.plist
+++ b/Info.plist
@@ -43,7 +43,7 @@
 				<key>Blue</key>
 				<integer>0</integer>
 				<key>Green</key>
-				<real>0.4</real>
+				<real>0.40000000000000002</real>
 				<key>Red</key>
 				<integer>1</integer>
 			</dict>
@@ -51,6 +51,12 @@
 			<false/>
 		</dict>
 	</dict>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
Hi, I've just made a very small change so when the BrowserController is displayed on iPhone, it can now also be rendered in landscape.  

I also tried to get the rest of the app to support landscape and it all seems to work, except when rendering the SubmissionTableCell (the text would stretch / compress when switching between landscape and portrait), so I've left it for now and just made the BrowserController support landscape.  
