### PR TITLE
Fixing issue #106 - Copying URLs absoluteURL in SharingController

### DIFF
--- a/Classes/Controllers/SharingController.m
+++ b/Classes/Controllers/SharingController.m
@@ -32,7 +32,7 @@
 
 - (id)initWithURL:(NSURL *)url_ title:(NSString *)title_ fromController:(UIViewController *)controller_ {
     if ((self = [super init])) {
-        url = [url_ copy];
+        url = [url_.absoluteURL copy];
         title = [title_ copy];
         controller = controller_; // XXX: retain this?
     }


### PR DESCRIPTION
- Copying the absolute URL in SharingController initWithURL: method to fix open in safari bug
