### PR TITLE
Populate the subject line with the item/page title when sharing by email

### DIFF
--- a/Classes/Controllers/LinkUIActivityItemSource.h
+++ b/Classes/Controllers/LinkUIActivityItemSource.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+#import "UIKit/UIActivityItemProvider.h"
+
+@interface LinkUIActivityItemSource : NSObject <UIActivityItemSource>
+
+    @property (strong, nonatomic) NSURL *url;
+    @property (strong, nonatomic) NSString *subject;
+
+    - (id) initWithURL: (NSURL *) url andSubject: (NSString *) subject;
+
+@end

--- a/Classes/Controllers/LinkUIActivityItemSource.m
+++ b/Classes/Controllers/LinkUIActivityItemSource.m
@@ -1,0 +1,26 @@
+#import "LinkUIActivityItemSource.h"
+
+@implementation LinkUIActivityItemSource
+
+    - (id) initWithURL: (NSURL *) url andSubject: (NSString *) subject {
+        if (self = [super init]) {
+            self.url = url;
+            self.subject = subject;
+        }
+        
+        return self;
+    }
+
+    - (id)activityViewControllerPlaceholderItem:(UIActivityViewController *)activityViewController {
+        return self.url;
+    }
+
+    - (id)activityViewController:(UIActivityViewController *)activityViewController itemForActivityType:(NSString *)activityType {
+        return self.url;
+    }
+
+    - (NSString *)activityViewController:(UIActivityViewController *)activityViewController subjectForActivityType:(NSString *)activityType {
+        return self.subject;
+    }
+
+@end

--- a/Classes/Controllers/SharingController.m
+++ b/Classes/Controllers/SharingController.m
@@ -7,6 +7,7 @@
 //
 
 #import "SharingController.h"
+#import "CommentListController.h"
 
 #import <MessageUI/MFMailComposeViewController.h>
 
@@ -20,6 +21,10 @@
 #import "OpenInSafariActivity.h"
 
 #import "BarButtonItem.h"
+
+@interface SharingController ()
+    - (NSString *) getSubject;
+@end
 
 @implementation SharingController
 
@@ -61,6 +66,7 @@
     [openInSafariActivity release];
 
     UIActivityViewController *activityController = [[UIActivityViewController alloc] initWithActivityItems:activityItems applicationActivities:applicationActivities];
+    [activityController setValue:[self getSubject] forKey:@"subject"];
 
     NSMutableArray *excludedActivityTypes = [NSMutableArray array];
     [excludedActivityTypes addObject:UIActivityTypePrint];
@@ -103,6 +109,14 @@
 
 - (void)showFromBarButtonItem:(BarButtonItem *)item {
     [self showFromView:nil barButtonItem:item atRect:CGRectNull];
+}
+
+- (NSString *) getSubject {
+    if ([controller isKindOfClass:[CommentListController class]]) {
+        return [title stringByAppendingString:@" | Hacker News"];
+    } else {
+        return title;
+    }
 }
 
 @end

--- a/Classes/Controllers/SharingController.m
+++ b/Classes/Controllers/SharingController.m
@@ -22,6 +22,8 @@
 
 #import "BarButtonItem.h"
 
+#import "LinkUIActivityItemSource.h"
+
 @interface SharingController ()
     - (NSString *) getSubject;
 @end
@@ -59,14 +61,13 @@
     InstapaperActivity *instapaperActivity = [[InstapaperActivity alloc] init];
     OpenInSafariActivity *openInSafariActivity = [[OpenInSafariActivity alloc] init];
     
-    NSArray *activityItems = [NSArray arrayWithObject:url];
+    NSArray *activityItems = [NSArray arrayWithObject:[[LinkUIActivityItemSource alloc] initWithURL:url andSubject:[self getSubject]]];
     NSArray *applicationActivities = [NSArray arrayWithObjects:instapaperActivity, openInSafariActivity, nil];
 
     [instapaperActivity release];
     [openInSafariActivity release];
 
     UIActivityViewController *activityController = [[UIActivityViewController alloc] initWithActivityItems:activityItems applicationActivities:applicationActivities];
-    [activityController setValue:[self getSubject] forKey:@"subject"];
 
     NSMutableArray *excludedActivityTypes = [NSMutableArray array];
     [excludedActivityTypes addObject:UIActivityTypePrint];

--- a/newsyc.xcodeproj/project.pbxproj
+++ b/newsyc.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		18B7E74A18497DCA00D30E4E /* Legacy-Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 18B7E73A18497DCA00D30E4E /* Legacy-Default.png */; };
 		18B7E74B18497DCA00D30E4E /* Legacy-Default@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 18B7E73B18497DCA00D30E4E /* Legacy-Default@2x.png */; };
 		18CA5DF8182ECD1100E54F4F /* ForceClearNavigationBar.m in Sources */ = {isa = PBXBuildFile; fileRef = 18CA5DF7182ECD1100E54F4F /* ForceClearNavigationBar.m */; };
+		2785D6831896F023001969AF /* LinkUIActivityItemSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 2785D6821896F023001969AF /* LinkUIActivityItemSource.m */; };
 		598ED48D16E6AAA4003A6BC2 /* libHNKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D563FF516E45AE000BDD2DB /* libHNKit.a */; };
 		7D1F98921320CF720059EBBB /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D1F98911320CF720059EBBB /* UIKit.framework */; };
 		7D1F98941320CF720059EBBB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D1F98931320CF720059EBBB /* Foundation.framework */; };
@@ -315,6 +316,8 @@
 		18B7E73B18497DCA00D30E4E /* Legacy-Default@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Legacy-Default@2x.png"; sourceTree = "<group>"; };
 		18CA5DF6182ECD1100E54F4F /* ForceClearNavigationBar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ForceClearNavigationBar.h; sourceTree = "<group>"; };
 		18CA5DF7182ECD1100E54F4F /* ForceClearNavigationBar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ForceClearNavigationBar.m; sourceTree = "<group>"; };
+		2785D6811896F023001969AF /* LinkUIActivityItemSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LinkUIActivityItemSource.h; sourceTree = "<group>"; };
+		2785D6821896F023001969AF /* LinkUIActivityItemSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LinkUIActivityItemSource.m; sourceTree = "<group>"; };
 		7D148E64132D68B5008FBF32 /* libxml2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.dylib; path = usr/lib/libxml2.dylib; sourceTree = SDKROOT; };
 		7D1F988D1320CF720059EBBB /* newsyc.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = newsyc.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7D1F98911320CF720059EBBB /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
@@ -797,6 +800,8 @@
 				7D56C3BD164CBD1500A18E7E /* OpenInSafariActivity.m */,
 				7DB809B814F8ACEE009668E6 /* SharingController.h */,
 				7DB809B914F8ACEF009668E6 /* SharingController.m */,
+				2785D6811896F023001969AF /* LinkUIActivityItemSource.h */,
+				2785D6821896F023001969AF /* LinkUIActivityItemSource.m */,
 			);
 			name = Sharing;
 			path = Controllers;
@@ -1121,6 +1126,7 @@
 				7DCB8115134ED75400B521F2 /* InstapaperAuthenticator.m in Sources */,
 				7DCB8116134ED75400B521F2 /* InstapaperRequest.m in Sources */,
 				7DCB8117134ED75400B521F2 /* InstapaperSession.m in Sources */,
+				2785D6831896F023001969AF /* LinkUIActivityItemSource.m in Sources */,
 				7D36ADCA13553935000613B2 /* ProgressHUD.m in Sources */,
 				7D91AA9F135A27DD00247D34 /* ActivityIndicatorItem.m in Sources */,
 				FA85248E1357BA73004E5A72 /* NSArray+Strings.m in Sources */,


### PR DESCRIPTION
Hi

Please can you consider incorporating this, or something like it, into a future release. It's handy to have the subject pre-populated when sharing links with people and is also useful when using share via email to [add to services like Pinboard](https://pinboard.in/howto/#post_by_mail) etc. I did see there was an [earlier pull request](https://github.com/Xuzz/newsyc/pull/94) about something similar, but I think that one was adding to the message body rather than the subject.

Screenshot as an example of what this looks like in the message composer:

![ios simulator screen shot 26 jan 2014 16 31 16](https://f.cloud.github.com/assets/30024/2004379/0d0af9e8-86a9-11e3-9ad1-e3340a4ff5de.png)
