### PR TITLE
Add option to open in Chrome

### DIFF
--- a/Classes/Controllers/OpenInChromeActivity.h
+++ b/Classes/Controllers/OpenInChromeActivity.h
@@ -1,0 +1,15 @@
+//
+//  OpenInChromeActivity.h
+//  newsyc
+//
+//  Created by Ayberk Tosun on 23/3/14.
+//
+//
+
+#import <UIKit/UIKit.h>
+
+@interface OpenInChromeActivity : UIActivity {
+    NSURL *url;
+}
+
+@end

--- a/Classes/Controllers/OpenInChromeActivity.m
+++ b/Classes/Controllers/OpenInChromeActivity.m
@@ -1,0 +1,44 @@
+//
+//  OpenInChromeActivity.m
+//  newsyc
+//
+//  Created by Ayberk Tosun on 23/3/14.
+//
+//
+
+#import "OpenInChromeActivity.h"
+#import "OpenInChromeController.h"
+
+@implementation OpenInChromeActivity
+
+- (void)dealloc {
+    [url release];
+    
+    [super dealloc];
+}
+
+- (NSString *)activityTitle {
+    return @"Open in Chrome";
+}
+
+//- (UIImage *)activityImage {
+//    TODO: Return "open in chrome" logo here
+//}
+
+- (BOOL)canPerformWithActivityItems:(NSArray *)activityItems {
+    return YES;
+}
+
+- (void)prepareWithActivityItems:(NSArray *)activityItems {
+    [url release];
+    
+    url = [[activityItems lastObject] copy];
+}
+
+- (void)performActivity {
+    OpenInChromeController *chromeController = [[OpenInChromeController alloc] init];
+    [chromeController openInChrome:url];
+    [self activityDidFinish:YES];
+}
+
+@end

--- a/Classes/Controllers/SharingController.m
+++ b/Classes/Controllers/SharingController.m
@@ -19,6 +19,10 @@
 
 #import "OpenInSafariActivity.h"
 
+#import "OpenInChromeActivity.h"
+#import "OpenInChromeController.h"
+
+
 #import "BarButtonItem.h"
 
 @implementation SharingController
@@ -55,8 +59,17 @@
     OpenInSafariActivity *openInSafariActivity = [[OpenInSafariActivity alloc] init];
     
     NSArray *activityItems = [NSArray arrayWithObject:url];
-    NSArray *applicationActivities = [NSArray arrayWithObjects:instapaperActivity, openInSafariActivity, nil];
-
+    NSMutableArray *applicationActivities = [NSMutableArray arrayWithObjects:instapaperActivity, openInSafariActivity, nil];
+    
+    OpenInChromeController *chromeController = [[OpenInChromeController alloc] init];
+    
+    // Display chrome activity only if it's installed.
+    if ([chromeController isChromeInstalled]) {
+        OpenInChromeActivity *openInChromeActivity = [[OpenInChromeActivity alloc] init];
+        [applicationActivities addObject:openInChromeActivity];
+        [openInChromeActivity release];
+    }
+        
     [instapaperActivity release];
     [openInSafariActivity release];
 

--- a/Classes/OpenInChromeController.h
+++ b/Classes/OpenInChromeController.h
@@ -1,0 +1,54 @@
+// Copyright 2012, Google Inc.
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,           
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY           
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import <Foundation/Foundation.h>
+
+// This class is used to check if Google Chrome is installed in the system and
+// to open a URL in Google Chrome either with or without a callback URL.
+@interface OpenInChromeController : NSObject
+
+// Returns a shared instance of the OpenInChromeController.
++ (OpenInChromeController *)sharedInstance;
+
+// Returns YES if Google Chrome is installed in the user's system.
+- (BOOL)isChromeInstalled;
+
+// Opens a URL in Google Chrome.
+- (BOOL)openInChrome:(NSURL *)url;
+
+// Open a URL in Google Chrome providing a |callbackURL| to return to the app.
+// URLs from the same app will be opened in the same tab unless |createNewTab|
+// is set to YES.
+// |callbackURL| can be nil.
+// The return value of this method is YES if the URL is successfully opened.
+- (BOOL)openInChrome:(NSURL *)url
+     withCallbackURL:(NSURL *)callbackURL
+        createNewTab:(BOOL)createNewTab;
+
+@end

--- a/Classes/OpenInChromeController.m
+++ b/Classes/OpenInChromeController.m
@@ -1,0 +1,135 @@
+// Copyright 2012, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import <UIKit/UIKit.h>
+
+#import "OpenInChromeController.h"
+
+static NSString * const kGoogleChromeHTTPScheme = @"googlechrome:";
+static NSString * const kGoogleChromeHTTPSScheme = @"googlechromes:";
+static NSString * const kGoogleChromeCallbackScheme =
+    @"googlechrome-x-callback:";
+
+static NSString * encodeByAddingPercentEscapes(NSString *input) {
+  NSString *encodedValue =
+      (NSString *)CFURLCreateStringByAddingPercentEscapes(
+          kCFAllocatorDefault,
+          (CFStringRef)input,
+          NULL,
+          (CFStringRef)@"!*'();:@&=+$,/?%#[]",
+          kCFStringEncodingUTF8);
+  return [encodedValue autorelease];
+}
+
+@implementation OpenInChromeController
+
++ (OpenInChromeController *)sharedInstance {
+  static OpenInChromeController *sharedInstance;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    sharedInstance = [[self alloc] init];
+  });
+  return sharedInstance;
+}
+
+- (BOOL)isChromeInstalled {
+  NSURL *simpleURL = [NSURL URLWithString:kGoogleChromeHTTPScheme];
+  NSURL *callbackURL = [NSURL URLWithString:kGoogleChromeCallbackScheme];
+  return  [[UIApplication sharedApplication] canOpenURL:simpleURL] ||
+      [[UIApplication sharedApplication] canOpenURL:callbackURL];
+}
+
+- (BOOL)openInChrome:(NSURL *)url {
+  return [self openInChrome:url withCallbackURL:nil createNewTab:NO];
+}
+
+- (BOOL)openInChrome:(NSURL *)url
+     withCallbackURL:(NSURL *)callbackURL
+        createNewTab:(BOOL)createNewTab {
+  NSURL *chromeSimpleURL = [NSURL URLWithString:kGoogleChromeHTTPScheme];
+  NSURL *chromeCallbackURL = [NSURL URLWithString:kGoogleChromeCallbackScheme];
+  if ([[UIApplication sharedApplication] canOpenURL:chromeCallbackURL]) {
+    NSString *appName =
+        [[NSBundle mainBundle]
+            objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+
+    NSString *scheme = [url.scheme lowercaseString];
+
+    // Proceed only if scheme is http or https.
+    if ([scheme isEqualToString:@"http"] ||
+        [scheme isEqualToString:@"https"]) {
+
+      NSMutableString *chromeURLString = [NSMutableString string];
+      [chromeURLString appendFormat:
+          @"%@//x-callback-url/open/?x-source=%@&url=%@",
+          kGoogleChromeCallbackScheme,
+          encodeByAddingPercentEscapes(appName),
+          encodeByAddingPercentEscapes([url absoluteString])];
+      if (callbackURL) {
+        [chromeURLString appendFormat:@"&x-success=%@",
+            encodeByAddingPercentEscapes([callbackURL absoluteString])];
+      }
+      if (createNewTab) {
+        [chromeURLString appendString:@"&create-new-tab"];
+      }
+
+      NSURL *chromeURL = [NSURL URLWithString:chromeURLString];
+
+      // Open the URL with Google Chrome.
+      return [[UIApplication sharedApplication] openURL:chromeURL];
+    }
+  } else if ([[UIApplication sharedApplication] canOpenURL:chromeSimpleURL]) {
+    NSString *scheme = [url.scheme lowercaseString];
+
+    // Replace the URL Scheme with the Chrome equivalent.
+    NSString *chromeScheme = nil;
+    if ([scheme isEqualToString:@"http"]) {
+      chromeScheme = kGoogleChromeHTTPScheme;
+    } else if ([scheme isEqualToString:@"https"]) {
+      chromeScheme = kGoogleChromeHTTPSScheme;
+    }
+
+    // Proceed only if a valid Google Chrome URI Scheme is available.
+    if (chromeScheme) {
+      NSString *absoluteString = [url absoluteString];
+      NSRange rangeForScheme = [absoluteString rangeOfString:@":"];
+      NSString *urlNoScheme =
+          [absoluteString substringFromIndex:rangeForScheme.location + 1];
+      NSString *chromeURLString =
+          [chromeScheme stringByAppendingString:urlNoScheme];
+      NSURL *chromeURL = [NSURL URLWithString:chromeURLString];
+
+      // Open the URL with Google Chrome.
+      return [[UIApplication sharedApplication] openURL:chromeURL];
+    }
+  }
+  return NO;
+}
+
+@end

--- a/newsyc.xcodeproj/project.pbxproj
+++ b/newsyc.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0000550218DF03A900BBF5A3 /* OpenInChromeActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = 0000550118DF03A900BBF5A3 /* OpenInChromeActivity.m */; };
+		0040549E18DF142100F76EA2 /* OpenInChromeController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0040549D18DF142100F76EA2 /* OpenInChromeController.m */; };
 		188DE37D17F7E92A00B498FC /* OrangeNavigationBar.m in Sources */ = {isa = PBXBuildFile; fileRef = 188DE37C17F7E92A00B498FC /* OrangeNavigationBar.m */; };
 		188DE38017F7EA5000B498FC /* OrangeBarView.m in Sources */ = {isa = PBXBuildFile; fileRef = 188DE37F17F7EA5000B498FC /* OrangeBarView.m */; };
 		188DE38317F7EA6200B498FC /* OrangeToolbar.m in Sources */ = {isa = PBXBuildFile; fileRef = 188DE38217F7EA6200B498FC /* OrangeToolbar.m */; };
@@ -199,6 +201,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0000550018DF03A900BBF5A3 /* OpenInChromeActivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OpenInChromeActivity.h; sourceTree = "<group>"; };
+		0000550118DF03A900BBF5A3 /* OpenInChromeActivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OpenInChromeActivity.m; sourceTree = "<group>"; };
+		0040549C18DF142100F76EA2 /* OpenInChromeController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OpenInChromeController.h; sourceTree = "<group>"; };
+		0040549D18DF142100F76EA2 /* OpenInChromeController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OpenInChromeController.m; sourceTree = "<group>"; };
 		188DE37B17F7E92A00B498FC /* OrangeNavigationBar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OrangeNavigationBar.h; sourceTree = "<group>"; };
 		188DE37C17F7E92A00B498FC /* OrangeNavigationBar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OrangeNavigationBar.m; sourceTree = "<group>"; };
 		188DE37E17F7EA5000B498FC /* OrangeBarView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OrangeBarView.h; sourceTree = "<group>"; };
@@ -672,6 +678,8 @@
 				7D6B9ED01347DF2E00CD923C /* Prefix.pch */,
 				7D2B8B8616ADCEF50072D730 /* PingController.h */,
 				7D2B8B8716ADCEF50072D730 /* PingController.m */,
+				0040549C18DF142100F76EA2 /* OpenInChromeController.h */,
+				0040549D18DF142100F76EA2 /* OpenInChromeController.m */,
 				7D6B9ED11347DF2E00CD923C /* AppDelegate.h */,
 				7D6B9ED21347DF2E00CD923C /* AppDelegate.m */,
 				7D6B9ECF1347DF2E00CD923C /* main.m */,
@@ -795,6 +803,8 @@
 				7D8541211640A09000C68F84 /* InstapaperActivity.m */,
 				7D56C3BC164CBD1500A18E7E /* OpenInSafariActivity.h */,
 				7D56C3BD164CBD1500A18E7E /* OpenInSafariActivity.m */,
+				0000550018DF03A900BBF5A3 /* OpenInChromeActivity.h */,
+				0000550118DF03A900BBF5A3 /* OpenInChromeActivity.m */,
 				7DB809B814F8ACEE009668E6 /* SharingController.h */,
 				7DB809B914F8ACEF009668E6 /* SharingController.m */,
 			);
@@ -935,7 +945,7 @@
 				LastUpgradeCheck = 0500;
 				TargetAttributes = {
 					7D1F988C1320CF720059EBBB = {
-						DevelopmentTeam = 6LV823278R;
+						DevelopmentTeam = 2BBVGHVRPQ;
 					};
 				};
 			};
@@ -1108,11 +1118,13 @@
 				7D6B9F4B1347DF2E00CD923C /* main.m in Sources */,
 				7D6B9F4C1347DF2E00CD923C /* AppDelegate.m in Sources */,
 				7D6B9F4E1347DF2E00CD923C /* DetailsHeaderView.m in Sources */,
+				0000550218DF03A900BBF5A3 /* OpenInChromeActivity.m in Sources */,
 				7D6B9F4F1347DF2E00CD923C /* PullToRefreshView.m in Sources */,
 				188DE38317F7EA6200B498FC /* OrangeToolbar.m in Sources */,
 				7D6B9F501347DF2E00CD923C /* EntryActionsView.m in Sources */,
 				188DE38A1803DFAE00B498FC /* TabBarController.m in Sources */,
 				7D6B9F521347DF2E00CD923C /* LoadingIndicatorView.m in Sources */,
+				0040549E18DF142100F76EA2 /* OpenInChromeController.m in Sources */,
 				7D6B9F531347DF2E00CD923C /* PlacardButton.m in Sources */,
 				7D6B9F541347DF2E00CD923C /* PlaceholderTextView.m in Sources */,
 				7D6B9F551347DF2E00CD923C /* ProfileHeaderView.m in Sources */,


### PR DESCRIPTION
If Chrome is installed on the device, an option to open in chrome is now added to the activity menu.

The icon is not ready though — was the open in Safari icon built-in? If someone knows of an existing “open in Chrome” icon that would be great.